### PR TITLE
Accordion doesn't work in ST2 PR or newer

### DIFF
--- a/Ux/layout/Accordion.js
+++ b/Ux/layout/Accordion.js
@@ -52,7 +52,7 @@ Ext.define('Ux.layout.Accordion', {
             var titleDock = item.titleDock = item.insert(0, {
                     xtype  : 'titlebar',
                     docked : 'top',
-                    title  : item.title,
+                    title  : me.innerItems[index].config.title,
                     items  : [
                         {
                             cls     : me.itemArrowCls,
@@ -93,9 +93,9 @@ Ext.define('Ux.layout.Accordion', {
     collapse: function(component) {
         if (component.isInnerItem() && !(this.getMode() === 'SINGLE' && this.getExpandedItem() === component)) {
             var titleDock   = component.titleDock,
-                titleHeight = titleDock.getEl().getHeight();
+                titleHeight = titleDock.element.getHeight();
 
-            component.fullHeight = component.getEl().getHeight();
+            component.fullHeight = component.element.getHeight();
             component.setHeight(titleHeight);
             component.collapsed = true;
             component.arrowButton.removeCls(this.itemArrowExpandedCls);


### PR DESCRIPTION
collapse/Expand and displaying the title of the titlebar don't work in ST2 PR or newer

changed: 
title in insertTitle()
and getEl() in collapse()
