### PR TITLE
Small fix to styles, workaround for one issue, one new option

### DIFF
--- a/Ux.layout.Accordion.css
+++ b/Ux.layout.Accordion.css
@@ -13,3 +13,5 @@
 .x-accordion-arrow-expanded {
     -webkit-transform : rotate(90deg);
 }
+
+.x-layout-accordion-item { overflow: hidden; }

--- a/Ux/layout/Accordion.js
+++ b/Ux/layout/Accordion.js
@@ -12,8 +12,9 @@ Ext.define('Ux.layout.Accordion', {
     itemArrowExpandedCls : Ext.baseCSSPrefix + 'accordion-arrow-expanded',
 
     config : {
-        expandedItem : null,
-        mode         : 'SINGLE'
+        expandedItem     : null,
+        mode             : 'SINGLE',
+        toggleOnTitlebar : false
     },
 
     constructor: function(container) {
@@ -61,7 +62,17 @@ Ext.define('Ux.layout.Accordion', {
                             scope   : me,
                             handler : 'handleToggleButton'
                         }
-                    ]
+                    ],
+                    listeners: {
+                      tap: {
+                        fn: function(event, el) {
+                          if (me.getToggleOnTitlebar()) {
+                            me.toggleCollapse(titleDock.up('component'));
+                          }
+                        },
+                        element: 'element'
+                      }
+                    }
                 }),
                 arrowBtn  = item.arrowButton = titleDock.down('button[cls=' + me.itemArrowCls + ']');
 

--- a/Ux/layout/Accordion.js
+++ b/Ux/layout/Accordion.js
@@ -99,7 +99,9 @@ Ext.define('Ux.layout.Accordion', {
             component.setHeight(titleHeight);
             component.collapsed = true;
             component.arrowButton.removeCls(this.itemArrowExpandedCls);
-            component.innerItems[0].element.removeCls('x-unsized');
+            if (component.innerItems[0]) {
+                component.innerItems[0].element.removeCls('x-unsized');
+            }
         }
     },
 
@@ -115,7 +117,9 @@ Ext.define('Ux.layout.Accordion', {
             component.setHeight(component.fullHeight);
             component.collapsed = false;
             component.arrowButton.addCls(this.itemArrowExpandedCls);
-            component.innerItems[0].element.addCls('x-unsized');
+            if (component.innerItems[0]) {
+                component.innerItems[0].element.addCls('x-unsized');
+            }
         }
     }
 });


### PR DESCRIPTION
The `overflow: hidden;` CSS accounts for content of a collapsed panel showing "under" the open panel in "SINGLE" mode. The `if` condition in the `collapse()` and `expand()` methods is a workaround for an issue I noticed where the `innerItems` were empty - most likely because the view was created, but not added to the Viewport yet.

The biggest change is a new option: `toggleOnTitlebar` which adds a tap handler to the entire titlebar for each accordion panel and allows the user to click/tap anywhere on the titlebar to toggle the accordion panel.
