### PR TITLE
More bug fixing on scrolling due to differences in multiple and single mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ Ext.setup({
             fullscreen : true,
             layout     : {
                 type : 'accordion',
-                toggleOnTitlebar : true,
+                toggleOnTitlebar : false,
                 mode : 'SINGLE'
             },
             scrollable : 'vertical',


### PR DESCRIPTION
- Fixed double event handler when using titlebar to toggle collapse/expand (causing effect to be cancelled sometimes)
- Fixed overshooting of scrolling in multiple or single mode (need different timing algorithms)
- Fixed mis-calculation of scrolling distance under certain conditions
